### PR TITLE
Make fn.flip only swap the first two arguments

### DIFF
--- a/build/fn.js
+++ b/build/fn.js
@@ -182,7 +182,11 @@ fn.memoize.serialize = function (values) {
 
 fn.flip = function (handler) {
 	return function () {
-		return fn.apply(handler, fn.reverse(arguments));
+		var argumentsArray = fn.toArray(arguments);
+		var firstTwo = argumentsArray.slice(0, 2);
+		var rest = argumentsArray.slice(2);
+
+		return fn.apply(handler, fn.concat(fn.reverse(firstTwo), rest));
 	};
 };
 
@@ -237,5 +241,6 @@ fn.debounce = function (handler, msDelay) {
 		}, msDelay);
 	};
 };
+
     return fn;
 }));

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,11 @@ fn.memoize.serialize = function (values) {
 
 fn.flip = function (handler) {
 	return function () {
-		return fn.apply(handler, fn.reverse(arguments));
+		var argumentsArray = fn.toArray(arguments);
+		var firstTwo = argumentsArray.slice(0, 2);
+		var rest = argumentsArray.slice(2);
+
+		return fn.apply(handler, fn.concat(fn.reverse(firstTwo), rest));
 	};
 };
 

--- a/tests/flip.js
+++ b/tests/flip.js
@@ -4,16 +4,16 @@ var expect = chai.expect;
 
 describe('.flip()', function () {
 
-	it('should reverse the order of argument application', function () {
+	it('should swap the first two arguments', function () {
 		var echo = fn.flip(function (a, b, c) {
 			return [a, b, c];
 		});
 
 		var values = echo(1, 2, 3);
 
-		expect(values[0]).to.equal(3);
-		expect(values[1]).to.equal(2);
-		expect(values[2]).to.equal(1);
+        expect(values[0]).to.equal(2);
+        expect(values[1]).to.equal(1);
+        expect(values[2]).to.equal(3);
 	});
 
 });


### PR DESCRIPTION
Currently, flip will reverse all the arguments. This is a problem when working with functions that take optional arguments at the end. For example, say you have:

``` javascript
var echo = function(a, b, includeNewline) {
    if (includeNewline) {
        return [a, b, "\n"];
    } else {
        return [a, b];
    }
};
var flipEcho = fn.flip(echo);
```

where `includeNewline` is an optional argument. You probably flipped it so you could partially apply `b`:

``` javascript
var partialEcho = fn.partial(flipEcho, 1);
```

The problem is that the argument you just partially applied is either `b` or `includeNewline` depending how many arguments you call it with:

``` javascript
partialEcho(2); // a = 2, b = 1
partialEcho(2, true); // a = true, b = 2, includeNewline = 1
```

and this was not the intention.

I think flip only really makes sense for the first two arguments anyway, and the use case is nearly always to partially apply the second argument. So this pull request makes flip only swap the first two arguments and leave the others in the same order.
