### PR TITLE
Prevent fn.curry from currying a function more than once

### DIFF
--- a/build/fn.js
+++ b/build/fn.js
@@ -73,19 +73,26 @@ fn.partial = function () {
 };
 
 fn.curry = function (handler, arity) {
+	if (handler.curried) {return handler;}
 	arity = arity || handler.length;
 
-	return function curry() {
+	function curry() {
 		var args = fn.toArray(arguments);
 
 		if (args.length >= arity) {
 			return handler.apply(null, args);
 		}
 
-		return function () {
+		function inner() {
 			return curry.apply(null, args.concat(fn.toArray(arguments)) );
-		};
-	};
+		}
+
+		inner.curried = true;
+		return inner;
+	}
+
+	curry.curried = true;
+	return curry;
 };
 
 fn.properties = function (object) {
@@ -237,5 +244,6 @@ fn.debounce = function (handler, msDelay) {
 		}, msDelay);
 	};
 };
+
     return fn;
 }));

--- a/src/index.js
+++ b/src/index.js
@@ -62,19 +62,26 @@ fn.partial = function () {
 };
 
 fn.curry = function (handler, arity) {
+	if (handler.curried) {return handler;}
 	arity = arity || handler.length;
 
-	return function curry() {
+	function curry() {
 		var args = fn.toArray(arguments);
 
 		if (args.length >= arity) {
 			return handler.apply(null, args);
 		}
 
-		return function () {
+		function inner() {
 			return curry.apply(null, args.concat(fn.toArray(arguments)) );
-		};
-	};
+		}
+
+		inner.curried = true;
+		return inner;
+	}
+
+	curry.curried = true;
+	return curry;
 };
 
 fn.properties = function (object) {


### PR DESCRIPTION
This makes `fn.curry` check to see its argument has already been curried. If it has, there is no need to curry it again. This improves performance, because if you curry a function more than once, it has to call through a stack of functions to get to the real one. In my testing, after currying a function 5,000 times the original way it took 24ms  to execute the function. After currying it 5,000 times in the new way it only took 1ms to execute. Also, running a function that was curried 10,000 in the old way caused a crash, whereas in the new way 10,000 curries is the same as 1 curry.

You can imagine the situation where a function takes an operator, for example `eq`, and wants to curry it.

``` javascript
function find(eq, collection) {
    eq = fn.curry(eq);
    ...
}
```

It's nice not to have to worry about whether or not `eq` was already curried before it was passed to find.

``` javascript
var eq = fn.curry(fn.op['===']);
find(eq(1), collection);
```
